### PR TITLE
Fix deprecated warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 _build
 .mooncakes/
 .DS_Store
+
+_build/
+target/

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -1,1 +1,6 @@
-{}
+{
+  "import": [
+    "moonbitlang/core/hashmap",
+    "moonbitlang/core/strconv"
+  ]
+}

--- a/parser.mbt
+++ b/parser.mbt
@@ -256,7 +256,7 @@ fn IniParseState::handle_value_char(
         state.left -= 1
         if state.left == 0 {
           // it must be 4 digits hex
-          let code = (try? @strconv.parse_int(state.hex.to_string(), base=16)).unwrap()
+          let code = try! @strconv.parse_int(state.hex.to_string(), base=16)
           self.ctx.buffer.write_char(Int::unsafe_to_char(code))
           self.escape_state = EscapeState::None
           self.last_char_is_backslash = false


### PR DESCRIPTION
Automated cleanup to eliminate warnings under `--warn-list @deprecated`.